### PR TITLE
Corrected Readme for usage of attributes as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ var result = anchorme(someText);
 // You can also pass few options
 
 anchorme(someText,{
-  attribute:{
+  attributes:{
     "target":"_blank"
   }
 })


### PR DESCRIPTION
The spelling of field attributes inside options in the code example (usage section) was attribute (s at end missing), as a result examples and Available options section were not in sync and caused confusion