### PR TITLE
Fix syntax error in .d.ts file

### DIFF
--- a/dist-node/util.d.ts
+++ b/dist-node/util.d.ts
@@ -20,7 +20,7 @@ export interface Options {
     truncate?: number | [number, number];
     defaultProtocol?: string | Function;
     list?: boolean;
-    exclude?: (URLObj) => boolean;
+    exclude?: (url: URLObj) => boolean;
 }
 /**
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,7 +23,7 @@ export interface Options {
 	truncate?:number|[number,number],
 	defaultProtocol?:string|Function,
 	list?:boolean,
-	exclude?:(URLObj)=>boolean
+	exclude?:(url:URLObj)=>boolean
 }
 
 /**


### PR DESCRIPTION
Caught when building without `skipLibCheck`