### PR TITLE
Add option to include text fragments along with detected urls. Makes …

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -86,6 +86,18 @@ describe('Additional functionalities', function () {
 		expect(result.length).toBe(2);
 	});
 
+	it('return a list of valid URLs mixed with text', function () {
+		var result = anchorme("one www.google.com two mail@gmail.com three",{
+			list:true,
+			includeStringsInList: true
+		});
+
+		expect(typeof result).toBe("object");
+		expect(result.length).toBe(9); //spaces come as separate fragments
+		expect(typeof result[2]).toBe("object"); //www.google.com
+		expect(typeof result[6]).toBe("object"); //mail@gmail.com
+	});
+
 	it('URLs validator works with emojis', function () {
 		expect(anchorme.validate.url("http://🐌🍏⌚✨😐😍🐸🍑.🍕💩.ws")).toBe(true);
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import hasprotocol from "./tests/hasprotocol";
 import {Options} from "./util";
 import {URLObj} from "./util";
 
-const anchorme:any = function(str:string,options?:Options):Array<URLObj>|string{
+const anchorme:any = function(str:string,options?:Options):Array<URLObj|string>|string{
 	options = defaultOptions(options);
 	var result = transform(str, options);
 	return result;

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -4,7 +4,7 @@ import {deSeparate} from "../separate/separate";
 import identify from "./identify";
 import {separate} from "../separate/separate";
 
-export default function(str,options:Options):string|Array<URLObj>{
+export default function(str,options:Options):string|Array<URLObj | string>{
 
 	var arr:Array<string> = separate(str);
 	var identified:Array<string|URLObj> = identify(arr,options);
@@ -20,10 +20,11 @@ export default function(str,options:Options):string|Array<URLObj>{
 
 	// return the current list (with words being filtered out)
 	if(options.list) {
-		var listed:Array<URLObj> = [];
+		var listed:Array<URLObj | string> = [];
 		for (var i = 0; i < identified.length; i++) {
 			var fragment = identified[i];
-			if(typeof fragment !== "string") listed.push(fragment);
+			if(!!options.includeStringsInList || typeof fragment !== "string") 
+				listed.push(fragment);
 		}
 		return listed;
 	}

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,6 +23,7 @@ export interface Options {
 	truncate?:number|[number,number],
 	defaultProtocol?:string|Function,
 	list?:boolean,
+	includeStringsInList?:boolean,
 	exclude?:(url:URLObj)=>boolean
 }
 
@@ -41,7 +42,8 @@ export function defaultOptions(options:Options|undefined):Options{
 			files:true,
 			truncate:Infinity,
 			defaultProtocol:"http://",
-			list:false
+			list:false,
+			includeStringsInList:false
 		};
 	}
 


### PR DESCRIPTION
…easier to parse and process the result to create dynamic DOM. Inserting converted HTML has security risk if input comes from untrusted source. And using list option alone will loose the original text.