### PR TITLE
Support native esm import

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 /*
 /*/
 !/dist/
+!/wrapper.mjs

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
 	"description": "A library to convert URLs to a clickable HTML anchor elements",
 	"main": "./dist/node/index.js",
 	"types": "./dist/node/index.d.ts",
+	"exports": {
+		".": {
+			"require": "./dist/node/index.js",
+			"import": "./wrapper.mjs"
+		},
+		"./": "./"
+	},
 	"scripts": {
 		"test": "mocha",
 		"testw": "mocha -w",

--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,0 +1,7 @@
+import anchorme from './dist/node/index.js';
+
+export default anchorme.default;
+export const {
+	list,
+	validate,
+} = anchorme.default;


### PR DESCRIPTION
Now that Node supports native esm imports, it makes sense that this library supports it as well. However
```js
import anchorme from 'anchorme';
```
produces an unexpected result as the `anchorme` variable will look like
```js
const anchorme = {
  default: {
    list() {},
    validate() {},
  },
};
```
in Node because of the way esm is transpiled to commonjs. This means that you have to resort to hacks like
```js
import _anchorme from 'anchorme';
const anchorme = _anchorme.default || _anchorme;
```
if you want your code to run both in the browser and in Node.

This PR circumvents this by leveraging [Node's conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports) and providing a `wrapper.mjs` file while maintaining full backwards compatibility for older Node versions.