### PR TITLE
Partial fix for URLs with localhost:port

### DIFF
--- a/src/regex.ts
+++ b/src/regex.ts
@@ -8,7 +8,7 @@ const ipv4 = `((?:(?:25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(?:25[0-5]|2[0-4]\\d|
 const ipv6 = `\\[(?:(?:[a-f\\d:]+:+)+[a-f\\d]+)\\]`;
 const port = `(:(\\d{1,5}))?`;
 const protocol = `(ht{2}ps?:|ftps?:)\\/\\/`;
-const confirmedByProtocol = `(${protocol})\\S+\\b`;
+const confirmedByProtocol = `(${protocol})[^'"<>&\\s]+\\b`;
 const fqdn = `(((${protocol})?(${domain}|${ipv4})(?=\\b|_)${port})|(?:${confirmedByProtocol}))`;
 
 export const email = `\\b(mailto:)?${emailAddress}@(${domain}|${ipv4})`;


### PR DESCRIPTION
Partially fixes https://github.com/alexcorvi/anchorme.js/issues/119

* Fixed: `localhost:port` URLs are now correctly delimited and no longer cause malformed HTML when passing existing `<a>` tags through `anchorme`
* Not fixed: `host` and `port` metadata are still missing from `list` results. This also applies to non-Latin-text URLs such as `http://www.عربي.com` and is due to the `confirmedByProtocol` regex fragment not capturing those parts. Might be worth fixing at some stage, but for now that metadata is simply missing for those types of URL (which is compatible with the TypeScript definitions). In any case, consumers in environments that support the native `URL` constructor can just use that to parse the URLs if needed:
   ```js
   const url = anchorme.list('http://localhost:8888')[0]
   url.port // undefined
   new URL(url.string).port // '8888'
   ```